### PR TITLE
chore: use node: protocol and export-from syntax

### DIFF
--- a/src/docs/swagger-docs.ts
+++ b/src/docs/swagger-docs.ts
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import path, { dirname } from 'path';
-import { fileURLToPath } from 'url';
+import fs from 'node:fs';
+import path, { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { swaggerSpec } from './swagger.js';
 
 const __filename = fileURLToPath(import.meta.url);

--- a/src/docs/swagger.ts
+++ b/src/docs/swagger.ts
@@ -1,5 +1,4 @@
 import swaggerJSDoc from 'swagger-jsdoc';
-import swaggerUiExpress from 'swagger-ui-express';
 import type { SwaggerUiOptions } from 'swagger-ui-express';
 
 /**
@@ -121,4 +120,5 @@ const customSwaggerUiOptions: SwaggerUiOptions = {
     },
 };
 
-export { validatedSwaggerSpecJSON as swaggerSpec, swaggerUiExpress as swaggerUi, customSwaggerUiOptions as swaggerUiOptions };
+export { validatedSwaggerSpecJSON as swaggerSpec, customSwaggerUiOptions as swaggerUiOptions };
+export { default as swaggerUi } from 'swagger-ui-express';

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 import app from './app.js';
-import http from 'http';
+import http from 'node:http';
 import dotenv from 'dotenv';
 
 // Loads environment variables from the .env file


### PR DESCRIPTION
Address SonarQube TypeScript issues:
- typescript:S7772: Import Node.js built-in modules using "node:" protocol
- typescript:S7763: Use "export...from" syntax for re-exports

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/ts-node-samples-express-restful/426)
<!-- Reviewable:end -->
