### PR TITLE
ci(workflow): add lint job as first gate in CI pipeline (#577)

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -10,7 +10,36 @@ on:
     branches: [master]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Lint commit messages
+        uses: wagoid/commitlint-github-action@v6.2.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6.3.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint source code
+        run: npm run lint
+
   build:
+    needs: lint
     runs-on: ubuntu-latest
 
     permissions:
@@ -43,9 +72,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-
-      - name: Lint commit messages
-        uses: wagoid/commitlint-github-action@v6.2.1
 
       - name: Set up Node.js
         uses: actions/setup-node@v6.3.0

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -15,6 +15,7 @@ jobs:
 
     permissions:
       contents: read
+      pull-requests: read
 
     steps:
       - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ This project uses football/soccer terminology for release names:
 
 ### Added
 
+- `lint` job to CI workflow as the first gate, running commitlint and ESLint before
+  `build`; all downstream jobs (`build → test → coverage`) now depend on it (#577)
+
 - Sequelize CLI migration infrastructure to replace the pre-seeded SQLite database
   file with version-controlled, reversible migrations (#107):
   - `.sequelizerc`: CLI config pointing to `config/database.cjs` and `database/migrations/`


### PR DESCRIPTION
## Summary

- Adds a `lint` job as the first step in the CI pipeline, running `wagoid/commitlint-github-action` and `npm run lint`
- Moves commitlint out of the `test` job into the new `lint` job
- Adds `needs: lint` to the `build` job; pipeline chain is now `lint → build → test → coverage`

## Test plan

- [x] Verify the `lint` job runs first and both linting steps pass on a clean PR
- [x] Verify a PR with ESLint violations fails CI before reaching `build`
- [x] Verify a PR with a malformed commit message fails CI before reaching `build`
- [x] Verify no regressions to `build`, `test`, and `coverage` jobs

Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/ts-node-samples-express-restful/580)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the continuous integration pipeline with automated code quality checks. Linting now runs as a dedicated quality gate before builds, ensuring higher code standards are consistently maintained across all updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->