### PR TITLE
feat(api): adopt 422 Unprocessable Entity for validation errors (#585)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ This project uses football/soccer terminology for release names:
 
 ### Changed
 
+- Validation errors now return `422 Unprocessable Entity` instead of `400 Bad Request`
+  to distinguish field-level validation failures from malformed requests (RFC 4918) (#585)
+
 ### Fixed
 
 ### Removed

--- a/src/controllers/player-controller.ts
+++ b/src/controllers/player-controller.ts
@@ -130,10 +130,10 @@ export default class PlayerController implements IPlayerController {
      *     responses:
      *       201:
      *         description: Created
-     *       400:
-     *         description: Bad Request
      *       409:
      *         description: Conflict
+     *       422:
+     *         description: Unprocessable Entity
      */
     async postAsync(request: Request, response: Response): Promise<void> {
         const create: IPlayerInput = request.body;
@@ -171,10 +171,10 @@ export default class PlayerController implements IPlayerController {
      *     responses:
      *       204:
      *         description: No Content
-     *       400:
-     *         description: Bad Request
      *       404:
      *         description: Not Found
+     *       422:
+     *         description: Unprocessable Entity
      */
     async putAsync(request: Request, response: Response): Promise<void> {
         const squadNumber = Number.parseInt(request.params.squadNumber);

--- a/src/middlewares/player-validator.ts
+++ b/src/middlewares/player-validator.ts
@@ -49,7 +49,7 @@ export default class PlayerValidator implements IPlayerValidator {
 
     /**
      * Middleware function that handles validation results.
-     * Returns 400 with error details if validation fails, otherwise calls next().
+     * Returns 422 with error details if validation fails, otherwise calls next().
      *
      * @param request - Express Request object
      * @param response - Express Response object
@@ -67,7 +67,7 @@ export default class PlayerValidator implements IPlayerValidator {
                 },
                 'Validation failed'
             );
-            response.status(400).json({ errors: errors.array() });
+            response.status(422).json({ errors: errors.array() });
             return;
         }
         next();

--- a/tests/player-test.ts
+++ b/tests/player-test.ts
@@ -182,7 +182,7 @@ describe('Integration Tests', () => {
         }, 60000); // Increase timeout for multiple requests
         // POST /players -------------------------------------------------------
         describe('/players', () => {
-            it('Request POST /players body empty → Response status 400 Bad Request', async () => {
+            it('Request POST /players body empty → Response status 422 Unprocessable Entity', async () => {
                 // Arrange
                 const body: Record<string, any> = {};
                 // Act
@@ -190,10 +190,10 @@ describe('Integration Tests', () => {
                     .post(path)
                     .send(body);
                 // Assert
-                expect(response.status).toBe(400);
+                expect(response.status).toBe(422);
                 expect(response.body.errors).toBeDefined();
             });
-            it('Request POST /players firstName missing → Response status 400 Bad Request', async () => {
+            it('Request POST /players firstName missing → Response status 422 Unprocessable Entity', async () => {
                 // Arrange
                 const body = { lastName: 'Doe', squadNumber: 10, position: 'Forward' };
                 // Act
@@ -201,11 +201,11 @@ describe('Integration Tests', () => {
                     .post(path)
                     .send(body);
                 // Assert
-                expect(response.status).toBe(400);
+                expect(response.status).toBe(422);
                 expect(response.body.errors).toBeDefined();
                 expect(hasFieldError(response.body.errors, 'firstName')).toBe(true);
             });
-            it('Request POST /players lastName missing → Response status 400 Bad Request', async () => {
+            it('Request POST /players lastName missing → Response status 422 Unprocessable Entity', async () => {
                 // Arrange
                 const body = { firstName: 'John', squadNumber: 10, position: 'Forward' };
                 // Act
@@ -213,11 +213,11 @@ describe('Integration Tests', () => {
                     .post(path)
                     .send(body);
                 // Assert
-                expect(response.status).toBe(400);
+                expect(response.status).toBe(422);
                 expect(response.body.errors).toBeDefined();
                 expect(hasFieldError(response.body.errors, 'lastName')).toBe(true);
             });
-            it('Request POST /players squadNumber missing → Response status 400 Bad Request', async () => {
+            it('Request POST /players squadNumber missing → Response status 422 Unprocessable Entity', async () => {
                 // Arrange
                 const body = { firstName: 'John', lastName: 'Doe', position: 'Forward' };
                 // Act
@@ -225,11 +225,11 @@ describe('Integration Tests', () => {
                     .post(path)
                     .send(body);
                 // Assert
-                expect(response.status).toBe(400);
+                expect(response.status).toBe(422);
                 expect(response.body.errors).toBeDefined();
                 expect(hasFieldError(response.body.errors, 'squadNumber')).toBe(true);
             });
-            it('Request POST /players position missing → Response status 400 Bad Request', async () => {
+            it('Request POST /players position missing → Response status 422 Unprocessable Entity', async () => {
                 // Arrange
                 const body = { firstName: 'John', lastName: 'Doe', squadNumber: 10 };
                 // Act
@@ -237,11 +237,11 @@ describe('Integration Tests', () => {
                     .post(path)
                     .send(body);
                 // Assert
-                expect(response.status).toBe(400);
+                expect(response.status).toBe(422);
                 expect(response.body.errors).toBeDefined();
                 expect(hasFieldError(response.body.errors, 'position')).toBe(true);
             });
-            it('Request POST /players squadNumber >99 → Response status 400 Bad Request', async () => {
+            it('Request POST /players squadNumber >99 → Response status 422 Unprocessable Entity', async () => {
                 // Arrange
                 const body = { firstName: 'John', lastName: 'Doe', squadNumber: 100, position: 'Forward' };
                 // Act
@@ -249,11 +249,11 @@ describe('Integration Tests', () => {
                     .post(path)
                     .send(body);
                 // Assert
-                expect(response.status).toBe(400);
+                expect(response.status).toBe(422);
                 expect(response.body.errors).toBeDefined();
                 expect(hasFieldError(response.body.errors, 'squadNumber')).toBe(true);
             });
-            it('Request POST /players squadNumber <1 → Response status 400 Bad Request', async () => {
+            it('Request POST /players squadNumber <1 → Response status 422 Unprocessable Entity', async () => {
                 // Arrange
                 const body = { firstName: 'John', lastName: 'Doe', squadNumber: 0, position: 'Forward' };
                 // Act
@@ -261,7 +261,7 @@ describe('Integration Tests', () => {
                     .post(path)
                     .send(body);
                 // Assert
-                expect(response.status).toBe(400);
+                expect(response.status).toBe(422);
                 expect(response.body.errors).toBeDefined();
                 expect(hasFieldError(response.body.errors, 'squadNumber')).toBe(true);
             });
@@ -333,7 +333,7 @@ describe('Integration Tests', () => {
         }, 60000); // Increase timeout for multiple requests
         // PUT /players/squadNumber/:squadNumber --------------------------------
         describe('/players/squadNumber/:squadNumber', () => {
-            it('Request PUT /players/squadNumber/{squadNumber} body empty → Response status 400 Bad Request', async () => {
+            it('Request PUT /players/squadNumber/{squadNumber} body empty → Response status 422 Unprocessable Entity', async () => {
                 // Arrange
                 const player = makeExistingPlayer();
                 const body: Record<string, any> = {};
@@ -342,10 +342,10 @@ describe('Integration Tests', () => {
                     .put(`${path}/squadNumber/${player.squadNumber}`)
                     .send(body);
                 // Assert
-                expect(response.status).toBe(400);
+                expect(response.status).toBe(422);
                 expect(response.body.errors).toBeDefined();
             });
-            it('Request PUT /players/squadNumber/{squadNumber} firstName missing → Response status 400 Bad Request', async () => {
+            it('Request PUT /players/squadNumber/{squadNumber} firstName missing → Response status 422 Unprocessable Entity', async () => {
                 // Arrange
                 const player = makeExistingPlayer();
                 const body = { lastName: 'Doe', squadNumber: player.squadNumber, position: 'Forward' };
@@ -354,11 +354,11 @@ describe('Integration Tests', () => {
                     .put(`${path}/squadNumber/${player.squadNumber}`)
                     .send(body);
                 // Assert
-                expect(response.status).toBe(400);
+                expect(response.status).toBe(422);
                 expect(response.body.errors).toBeDefined();
                 expect(hasFieldError(response.body.errors, 'firstName')).toBe(true);
             });
-            it('Request PUT /players/squadNumber/{squadNumber} lastName missing → Response status 400 Bad Request', async () => {
+            it('Request PUT /players/squadNumber/{squadNumber} lastName missing → Response status 422 Unprocessable Entity', async () => {
                 // Arrange
                 const player = makeExistingPlayer();
                 const body = { firstName: 'John', squadNumber: player.squadNumber, position: 'Forward' };
@@ -367,11 +367,11 @@ describe('Integration Tests', () => {
                     .put(`${path}/squadNumber/${player.squadNumber}`)
                     .send(body);
                 // Assert
-                expect(response.status).toBe(400);
+                expect(response.status).toBe(422);
                 expect(response.body.errors).toBeDefined();
                 expect(hasFieldError(response.body.errors, 'lastName')).toBe(true);
             });
-            it('Request PUT /players/squadNumber/{squadNumber} squadNumber missing → Response status 400 Bad Request', async () => {
+            it('Request PUT /players/squadNumber/{squadNumber} squadNumber missing → Response status 422 Unprocessable Entity', async () => {
                 // Arrange
                 const player = makeExistingPlayer();
                 const body = { firstName: 'John', lastName: 'Doe', position: 'Forward' };
@@ -380,11 +380,11 @@ describe('Integration Tests', () => {
                     .put(`${path}/squadNumber/${player.squadNumber}`)
                     .send(body);
                 // Assert
-                expect(response.status).toBe(400);
+                expect(response.status).toBe(422);
                 expect(response.body.errors).toBeDefined();
                 expect(hasFieldError(response.body.errors, 'squadNumber')).toBe(true);
             });
-            it('Request PUT /players/squadNumber/{squadNumber} position missing → Response status 400 Bad Request', async () => {
+            it('Request PUT /players/squadNumber/{squadNumber} position missing → Response status 422 Unprocessable Entity', async () => {
                 // Arrange
                 const player = makeExistingPlayer();
                 const body = { firstName: 'John', lastName: 'Doe', squadNumber: player.squadNumber };
@@ -393,11 +393,11 @@ describe('Integration Tests', () => {
                     .put(`${path}/squadNumber/${player.squadNumber}`)
                     .send(body);
                 // Assert
-                expect(response.status).toBe(400);
+                expect(response.status).toBe(422);
                 expect(response.body.errors).toBeDefined();
                 expect(hasFieldError(response.body.errors, 'position')).toBe(true);
             });
-            it('Request PUT /players/squadNumber/{squadNumber} squadNumber >99 → Response status 400 Bad Request', async () => {
+            it('Request PUT /players/squadNumber/{squadNumber} squadNumber >99 → Response status 422 Unprocessable Entity', async () => {
                 // Arrange
                 const player = makeExistingPlayer();
                 const body = { firstName: 'John', lastName: 'Doe', squadNumber: 100, position: 'Forward' };
@@ -406,11 +406,11 @@ describe('Integration Tests', () => {
                     .put(`${path}/squadNumber/${player.squadNumber}`)
                     .send(body);
                 // Assert
-                expect(response.status).toBe(400);
+                expect(response.status).toBe(422);
                 expect(response.body.errors).toBeDefined();
                 expect(hasFieldError(response.body.errors, 'squadNumber')).toBe(true);
             });
-            it('Request PUT /players/squadNumber/{squadNumber} squadNumber <1 → Response status 400 Bad Request', async () => {
+            it('Request PUT /players/squadNumber/{squadNumber} squadNumber <1 → Response status 422 Unprocessable Entity', async () => {
                 // Arrange
                 const player = makeExistingPlayer();
                 const body = { firstName: 'John', lastName: 'Doe', squadNumber: 0, position: 'Forward' };
@@ -419,7 +419,7 @@ describe('Integration Tests', () => {
                     .put(`${path}/squadNumber/${player.squadNumber}`)
                     .send(body);
                 // Assert
-                expect(response.status).toBe(400);
+                expect(response.status).toBe(422);
                 expect(response.body.errors).toBeDefined();
                 expect(hasFieldError(response.body.errors, 'squadNumber')).toBe(true);
             });


### PR DESCRIPTION
## Summary

- Replaces `400 Bad Request` with `422 Unprocessable Entity` for field validation failures in `PlayerValidator.validate()`, reserving `400` for malformed requests (unparseable JSON, wrong `Content-Type`)
- Updates `@openapi` JSDoc annotations on `POST /players` and `PUT /players/squadNumber/{squadNumber}` to declare `422` responses
- Updates all 14 validation test assertions and `it()` descriptions to expect `422 Unprocessable Entity`
- Regenerates `swagger.json` via `npm run swagger:docs`

## Test plan

- [x] `npm run lint` — ESLint passes
- [x] `npx tsc --noEmit` — TypeScript compiles clean
- [x] `npm run coverage` — 32 tests pass, 100% coverage maintained
- [x] `npm run swagger:docs` — `swagger.json` regenerated with `422` on POST and PUT endpoints
- [x] `npm run lint:commit` — Conventional Commits validation passes
- [x] `docker compose build` — image builds successfully
- [x] CodeRabbit review — no findings

Closes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/ts-node-samples-express-restful/601)
<!-- Reviewable:end -->
