### PR TITLE
docs(adr): add full-replace PUT, AI workflow and SDD records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ This project uses football/soccer terminology for release names:
 
 ### Added
 
+- ADR-013: Use Full-Replace PUT as the Partial Update Strategy
+- ADR-014: Adopt AI-Assisted Development Workflow
+- ADR-015: Adopt Spec-Driven Development (SDD)
+
 ### Changed
 
 - Validation errors now return `422 Unprocessable Entity` instead of `400 Bad Request`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ Example: `feat(api): add player stats endpoint (#42)`
 
 ## Architecture Decision Records
 
-Significant architectural decisions are documented in [`docs/adr/`](docs/adr/) (ADR-001–012). Load these before proposing structural changes — they explain the **why** behind the key decisions in this project. When proposing a change that alters an accepted decision, create a new ADR rather than editing the existing one.
+Significant architectural decisions are documented in [`docs/adr/`](docs/adr/) (ADR-001–015). Load these before proposing structural changes — they explain the **why** behind the key decisions in this project. When proposing a change that alters an accepted decision, create a new ADR rather than editing the existing one.
 
 ## Agent Mode
 

--- a/docs/adr/013-full-replace-put-no-patch.md
+++ b/docs/adr/013-full-replace-put-no-patch.md
@@ -1,0 +1,43 @@
+# ADR-013: Use Full-Replace PUT as the Partial Update Strategy
+
+## Status
+
+Accepted
+
+Date: 2026-06-10
+
+## Context
+
+HTTP defines PUT (full replacement) and PATCH (partial update). Both are
+standard; the choice affects API surface complexity, client requirements,
+and server-side validation. For a resource as small as a player object,
+the tradeoff between the two methods is relevant.
+
+## Decision
+
+We use PUT for all player update operations (`PUT /players/squadNumber/:n`).
+The request body must contain the full player representation; the server
+replaces the stored resource entirely. No PATCH endpoint is provided at
+this time. A PATCH implementation is tracked in the project backlog and
+remains under active consideration.
+
+## Consequences
+
+### Positive
+
+- Simpler server-side implementation — single validation path, no
+  partial-update merge logic
+- PUT semantics are idempotent and well-understood
+- Consistent with all sibling repos in the cross-language comparison set
+
+### Negative
+
+- Clients must send the full resource even for single-field changes;
+  fine-grained updates require a GET + full PUT round-trip
+- PATCH remains in the backlog — if implemented, this ADR will be
+  superseded
+
+### Neutral
+
+- Standard REST semantics; no ambiguity about the update contract for
+  current consumers

--- a/docs/adr/014-ai-assisted-development-workflow.md
+++ b/docs/adr/014-ai-assisted-development-workflow.md
@@ -1,0 +1,76 @@
+# ADR-014: Adopt AI-Assisted Development Workflow
+
+## Status
+
+Accepted
+
+Date: 2026-06-10
+
+## Context
+
+Software development has historically relied on three successive layers
+of knowledge:
+
+1. **Official documentation** — authoritative but static; describes the
+   intended API but not how real projects apply it
+2. **Community collaboration** — Stack Overflow, GitHub Discussions, blog
+   posts; describes how practitioners actually solve problems, but requires
+   the developer to synthesize and apply that knowledge themselves
+3. **AI synthesis** — models trained on both layers above, capable of
+   applying idiomatic, stack-specific knowledge directly to a given
+   codebase
+
+Agentic AI tools represent a qualitative shift: instead of consulting
+knowledge and applying it manually, the developer delegates implementation
+to an agent that has absorbed the collective idioms of a stack — "the
+Microsoft way", "the Node.js way" — and can apply them consistently.
+
+For a cross-language REST API comparison project, this matters
+particularly: each implementation should reflect how an experienced
+practitioner in that stack would structure the same problem, not a
+generic approach that happens to compile.
+
+Prior to Claude Code, AI assistance was used ad-hoc — pasting code into
+web interfaces (ChatGPT, DeepSeek) or via IDE-integrated assistants
+(GitHub Copilot). Both approaches lack persistent codebase context and
+the ability to act autonomously across a project.
+
+## Decision
+
+We adopt Claude Code as the primary development workflow tool for this
+project.
+
+A `CLAUDE.md` file at the repository root serves as the workflow
+specification: it documents architecture, coding conventions, invariants,
+and explicit boundaries for autonomous operation — what the agent may do
+freely, what requires human approval, and what must never be changed.
+
+CodeRabbit provides an additional automated code review layer
+independent of the primary workflow.
+
+## Consequences
+
+### Positive
+
+- Stack-specific idioms are enforced by the agent's collective knowledge
+  rather than individual developer discipline
+- `CLAUDE.md` is living architectural documentation: it must stay
+  accurate for the workflow to function, creating a natural incentive to
+  keep it current
+- Explicit autonomy boundaries make human oversight intentional rather
+  than incidental
+
+### Negative
+
+- Token economics: long-running work may exceed context limits, requiring
+  active session management and continuation prompts to resume work
+  across sessions
+- The global `~/.claude/CLAUDE.md` and per-repo `CLAUDE.md` must stay
+  aligned; drift between them produces inconsistent agent behavior
+
+### Neutral
+
+- Development workflow moves to the terminal/CLI rather than an IDE;
+  this has no impact on the codebase itself
+- `CLAUDE.md` is specific to Claude Code; a different tool would require
+  a different workflow specification format

--- a/docs/adr/015-spec-driven-development.md
+++ b/docs/adr/015-spec-driven-development.md
@@ -1,0 +1,61 @@
+# ADR-015: Adopt Spec-Driven Development (SDD)
+
+## Status
+
+Accepted
+
+Date: 2026-06-10
+
+## Context
+
+In an agentic development workflow, it is easy to begin implementation
+before requirements are fully understood. An AI assistant will produce
+working code from a vague prompt — but working and correct are not the
+same thing. Without a forcing function that requires requirements to be
+stated explicitly before implementation begins, scope creep, rework, and
+misaligned implementations are likely outcomes.
+
+GitHub Issues provide a natural spec artifact: persistent, linkable,
+and — critically — they survive session boundaries. In a workflow where
+context is lost between sessions, an Issue that captures the agreed
+approach and acceptance criteria before implementation begins serves as
+the durable contract between intent and implementation.
+
+## Decision
+
+All new features and non-trivial changes follow a three-step workflow:
+
+1. **Discuss** — describe the requirement in Claude Code Plan mode;
+   explore alternatives and consequences before committing to an approach
+2. **Specify** — create a GitHub Issue as the spec artifact, capturing
+   the agreed approach, acceptance criteria, and any constraints
+3. **Implement** — work against the Issue; commits reference it via
+   the `(#issue)` suffix in the Conventional Commits format
+
+Trivial changes (documentation updates, formatting fixes, dependency
+bumps) may skip the Issue step at the developer's discretion.
+
+## Consequences
+
+### Positive
+
+- Requirements are stated explicitly before implementation; the agent
+  works against a written spec rather than an interpreted prompt
+- Issues survive session boundaries — a new session can resume from
+  the Issue rather than reconstructing intent from scratch
+- The implementation trail (Issue → branch → PR → commit) is traceable
+  without relying on session memory
+
+### Negative
+
+- Adds upfront overhead for changes that feel small; the Issue step can
+  seem bureaucratic for straightforward work
+- The line between "spec-worthy" and "trivial" is judgment-dependent
+  and not enforced by tooling
+
+### Neutral
+
+- GitHub Issues double as the project backlog; SDD and backlog
+  management share the same artifact
+- Plan mode discussion is ephemeral — not persisted outside the session;
+  the Issue is the only durable record of the pre-implementation reasoning

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,9 @@ ADRs document architecturally significant decisions: their context, the decision
 | [010](010-use-tsx-over-ts-node.md) | Use tsx instead of ts-node | Accepted |
 | [011](011-football-semantic-versioning.md) | Football-themed semantic versioning | Accepted |
 | [012](012-sequelize-cli-migrations.md) | Use Sequelize CLI for schema migrations | Accepted |
+| [013](013-full-replace-put-no-patch.md) | Use Full-Replace PUT as the Partial Update Strategy | Accepted |
+| [014](014-ai-assisted-development-workflow.md) | Adopt AI-Assisted Development Workflow | Accepted |
+| [015](015-spec-driven-development.md) | Adopt Spec-Driven Development (SDD) | Accepted |
 
 ## Creating a new ADR
 


### PR DESCRIPTION
## Summary

- ADR-013: Documents the decision to use full-replace PUT (no PATCH) for player update operations, with rationale on idempotency, simplicity, and cross-repo consistency
- ADR-014: Formalises Claude Code as the primary development workflow tool, with `CLAUDE.md` as the workflow specification and CodeRabbit as the secondary review layer
- ADR-015: Formalises Spec-Driven Development (SDD) — Discuss → Specify (GitHub Issue) → Implement — as the required workflow for all non-trivial changes

Also updates `docs/adr/README.md` index, `CHANGELOG.md` `[Unreleased]` section, and `CLAUDE.md` ADR range reference (001–012 → 001–015).

## Test plan

- [ ] All three ADR files render correctly on GitHub (headings, lists, links)
- [ ] `docs/adr/README.md` index links resolve to the new files
- [ ] `CHANGELOG.md` `[Unreleased]` section contains the three new entries
- [ ] `CLAUDE.md` ADR range reads `ADR-001–015`
- [ ] CI passes (lint, type-check, tests, coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/ts-node-samples-express-restful/658)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Architecture Decision Records documentation by adding three new decisions covering full-replace HTTP `PUT` update strategy (no partial updates), an AI-assisted development workflow, and a spec-driven development process.
  * Updated the changelog and workflow guide to reference the new ADR range (ADRs 001–015).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->